### PR TITLE
Update GroovyExtensionMetaClassRegistry.groovy

### DIFF
--- a/aem-groovy-extension-bundle/src/main/groovy/com/citytechinc/aem/groovy/extension/metaclass/GroovyExtensionMetaClassRegistry.groovy
+++ b/aem-groovy-extension-bundle/src/main/groovy/com/citytechinc/aem/groovy/extension/metaclass/GroovyExtensionMetaClassRegistry.groovy
@@ -247,9 +247,19 @@ class GroovyExtensionMetaClassRegistry {
                 break
             case PropertyType.STRING:
                 result = value.string
+                break
+            case PropertyType.REFERENCE:
+                result = getNodeFromValue(value)
+            case PropertyType.WEAKREFERENCE:
+                result = getNodeFromValue(value)
         }
 
         result
+    }
+
+    private static def getNodeFromValue(value) {
+        def uuid = value.string
+        uuid ? value.session.getNodeByIdentifier(uuid) : null
     }
 
     private static void registerPageMetaClass() {


### PR DESCRIPTION
Extend node's get metaclass extension so that it supports retrieval of referenced nodes.

The method used to retrieve nodes by UUID from session is taken from Jackrabbit's code: http://svn.apache.org/repos/asf/jackrabbit/trunk/jackrabbit-core/src/main/java/org/apache/jackrabbit/core/PropertyImpl.java

Currently, the Property API does not provide an easy way of retrieving referenced nodes if the property is multivalued.
