### PR TITLE
AEM 6.2-compatible OSGI package imports

### DIFF
--- a/aem-groovy-extension-bundle/pom.xml
+++ b/aem-groovy-extension-bundle/pom.xml
@@ -49,6 +49,11 @@
                         <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
                         <Export-Package>!*.impl,com.citytechinc.aem.groovy.extension.*</Export-Package>
                         <DynamicImport-Package>*</DynamicImport-Package>
+                        <!-- Exported package versions differ in major version between AEM61 and AEM62 -->
+                        <Import-Package>
+                          com.day.cq.commons.jcr;version="[5.7,7)",
+                          *
+                        </Import-Package>
                     </instructions>
                 </configuration>
             </plugin>


### PR DESCRIPTION
fix OSGi package imports to be compatible with both AEM 6.1 and AEM 6.2
